### PR TITLE
feat: Dom Helpers for more concise block code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     'import/extensions': ['error', {
       js: 'always',
     }],
+    'function-paren-newline': 'off',
   },
 };

--- a/scripts/dom-helpers.js
+++ b/scripts/dom-helpers.js
@@ -1,0 +1,76 @@
+/* eslint-disable no-param-reassign */
+
+/**
+ * Example Usage:
+ *
+ * domEl('main',
+ *  div({ class: 'card' },
+ *  a({ href: item.path },
+ *    div({ class: 'card-thumb' },
+ *     createOptimizedPicture(item.image, item.title, 'lazy', [{ width: '800' }]),
+ *    ),
+ *   div({ class: 'card-caption' },
+ *      h3(item.title),
+ *      p({ class: 'card-description' }, item.description),
+ *      p({ class: 'button-container' },
+ *       a({ href: item.path, 'aria-label': 'Read More', class: 'button primary' }, 'Read More'),
+ *     ),
+ *   ),
+ *  ),
+ * )
+ */
+
+/**
+ * Helper for more concisely generating DOM Elements with attributes and children
+ * @param {string} tag HTML tag of the desired element
+ * @param  {[Object?, ...Element]} items: First item can optionally be an object of attributes,
+ *  everything else is a child element
+ * @returns {Element} The constructred DOM Element
+ */
+export function domEl(tag, ...items) {
+  const element = document.createElement(tag);
+
+  if (!items || items.length === 0) return element;
+
+  if (!(items[0] instanceof Element || items[0] instanceof HTMLElement) && typeof items[0] === 'object') {
+    const [attributes, ...rest] = items;
+    items = rest;
+
+    Object.entries(attributes).forEach(([key, value]) => {
+      if (!key.startsWith('on')) {
+        element.setAttribute(key, Array.isArray(value) ? value.join(' ') : value);
+      } else {
+        element.addEventListener(key.substring(2).toLowerCase(), value);
+      }
+    });
+  }
+
+  items.forEach((item) => {
+    item = item instanceof Element || item instanceof HTMLElement
+      ? item
+      : document.createTextNode(item);
+    element.appendChild(item);
+  });
+
+  return element;
+}
+
+/*
+  More short hand functions can be added for very common DOM elements below.
+  domEl function from above can be used for one off DOM element occurrences.
+*/
+export function div(...items) { return domEl('div', ...items); }
+export function p(...items) { return domEl('p', ...items); }
+export function a(...items) { return domEl('a', ...items); }
+export function h1(...items) { return domEl('h1', ...items); }
+export function h2(...items) { return domEl('h2', ...items); }
+export function h3(...items) { return domEl('h3', ...items); }
+export function h4(...items) { return domEl('h4', ...items); }
+export function h5(...items) { return domEl('h5', ...items); }
+export function h6(...items) { return domEl('h6', ...items); }
+export function ul(...items) { return domEl('ul', ...items); }
+export function li(...items) { return domEl('li', ...items); }
+export function i(...items) { return domEl('i', ...items); }
+export function img(...items) { return domEl('img', ...items); }
+export function span(...items) { return domEl('span', ...items); }
+export function button(...items) { return domEl('button', ...items); }

--- a/test/scripts/dom-helpers.test.js
+++ b/test/scripts/dom-helpers.test.js
@@ -1,0 +1,88 @@
+/* global describe it */
+import { expect } from '@esm-bundle/chai';
+import {
+  domEl, div, a, p, h3, button,
+} from '../../scripts/dom-helpers.js';
+
+describe('Dom Helpers', () => {
+  it('Simple DOM El', () => {
+    const result = domEl('p', 'Simple text');
+    expect(result.tagName).to.equal('P');
+    expect(result.textContent).to.equal('Simple text');
+  });
+
+  it('DOM with attribute', () => {
+    const result = domEl('p', { class: 'paragraph' }, 'Simple text');
+    expect(result.tagName).to.equal('P');
+    expect(result.getAttribute('class')).to.equal('paragraph');
+    expect(result.textContent).to.equal('Simple text');
+  });
+
+  it('Paragraph with attribute and text', () => {
+    const result = p({ class: 'paragraph' }, 'Simple text');
+    expect(result.tagName).to.equal('P');
+    expect(result.getAttribute('class')).to.equal('paragraph');
+    expect(result.textContent).to.equal('Simple text');
+  });
+
+  it('Event listeners', () => {
+    let eventTriggered = false;
+    const result = (
+      button({ class: 'btn primary', onclick: () => { eventTriggered = true; } },
+        'My Button',
+      )
+    );
+
+    result.click();
+    expect(eventTriggered).to.equal(true);
+  });
+
+  it('Complex test', () => {
+    const result = domEl('main',
+      div({ class: 'card' },
+        a({ href: '/path/to/resource' },
+          div({ class: 'card-caption' },
+            h3('This is a title'),
+            p({ class: 'card-description' }, 'This is a description'),
+            p({ class: 'button-container' },
+              a({ href: '/path/to/resource', 'aria-label': 'Read More', class: 'button primary' }, 'Read More'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.tagName).to.equal('MAIN');
+    expect(result.children.length).to.equal(1);
+    expect(result.children[0].tagName).to.equal('DIV');
+    expect(result.children[0].getAttribute('class')).to.equal('card');
+    expect(result.children[0].children.length).to.equal(1);
+    expect(result.children[0].children[0].tagName).to.equal('A');
+    expect(result.children[0].children[0].getAttribute('href')).to.equal('/path/to/resource');
+    expect(result.children[0].children[0].children.length).to.equal(1);
+
+    const cardCaption = result.children[0].children[0].children[0];
+    expect(cardCaption.tagName).to.equal('DIV');
+    expect(cardCaption.children.length).to.equal(3);
+    expect(cardCaption.getAttribute('class')).to.equal('card-caption');
+
+    expect(cardCaption.children[0].children.length).to.equal(0);
+    expect(cardCaption.children[0].tagName).to.equal('H3');
+    expect(cardCaption.children[0].textContent).to.equal('This is a title');
+
+    expect(cardCaption.children[1].tagName).to.equal('P');
+    expect(cardCaption.children[1].getAttribute('class')).to.equal('card-description');
+    expect(cardCaption.children[1].textContent).to.equal('This is a description');
+
+    expect(cardCaption.children[2].tagName).to.equal('P');
+    expect(cardCaption.children[2].getAttribute('class')).to.equal('button-container');
+    expect(cardCaption.children[2].children.length).to.equal(1);
+
+    const cardButton = cardCaption.children[2].children[0];
+    expect(cardButton.getAttribute('href')).to.equal('/path/to/resource');
+    expect(cardButton.getAttribute('aria-label')).to.equal('Read More');
+    expect(cardButton.classList[0]).to.equal('button');
+    expect(cardButton.classList[1]).to.equal('primary');
+    expect(cardButton.textContent).to.equal('Read More');
+  });
+});


### PR DESCRIPTION
Initially submitted as a PR to the boilerplate. See discussion there as well: https://github.com/adobe/helix-project-boilerplate/pull/210

## Context
This PR adds a small JS file to help with DOM elements generation.
We've been using this in our project and it speeds up a lot the development, code reviews and testing, so I thought it might be useful for new projects as well.

https://github.com/hlxsites/moleculardevices/pull/161

## Why?
The following Dom Helper functions allow for:
* a more concise code
* composable structure
* dom like syntax structure to easily visualise the resulting HTML when looking at the code
* faster development and code review of block code
* while maintaining  100 LHS for performance
* 100% vanilla JS / no compilation required
* with minimal overhead - a few ifs and function calls

## Main Usecases
* DOM rendering of dynamic data from spreadsheets and indexes
* Adding new DOM elements during block decoration to what Franklin provides, based on the word document (e.g. adding buttons for a carousel, where the elements are coming from the word document)

## Examples
It allows rewrite from:
```javascript
function renderItem(item) {
  const newsItem = document.createElement('div');
  newsItem.classList.add('blog-carousel-item');
  const newsItemLink = document.createElement('a');
  newsItemLink.href = item.path;
  newsItem.append(newsItemLink);
  const newsThumb = document.createElement('div');
  newsThumb.classList.add('blog-carousel-thumb');
  newsThumb.append(createOptimizedPicture(item.image, item.title, 'lazy', [{ width: '800' }]));
  newsItemLink.appendChild(newsThumb);
  const newsCaption = document.createElement('div');
  newsCaption.classList.add('blog-carousel-caption');
  newsCaption.innerHTML = `
    <h3>${item.title}</h3>
    <p class="blog-description">${item.description}</p>
    <p class="button-container">
      <a href=${item.path} aria-label="Read More" class="button primary">Read More</a>
    </p>
  `;
  newsItemLink.appendChild(newsCaption);
  return newsItem;
}
```

To:
```javascript
function renderItem(item) {
  return (
    div({ class: 'blog-carousel-item' },
      a({ href: item.path },
        div({ class: 'blog-carousel-thumb' },
          createOptimizedPicture(item.image, item.title, 'lazy', [{ width: '800' }]),
        ),
        div({ class: 'blog-carousel-caption' },
          h3(item.title),
          p({ class: 'blog-description' }, item.description),
          p({ class: 'button-container' },
            a({ href: item.path, 'aria-label': 'Read More', class: 'button primary' }, 'Read More'),
          ),
        ),
      ),
    )
  );
}
```

More examples from our project code:
* https://github.com/hlxsites/moleculardevices/blob/fd7123c54a42805bb2cb44098e750525d7e2e830/templates/blog/blog.js#L53-L75
* https://github.com/hlxsites/moleculardevices/blob/main/blocks/related-assay-data/related-assay-data.js#L33-L41
* https://github.com/hlxsites/moleculardevices/blob/main/blocks/social-share/social-share.js#L66-L78
* https://github.com/hlxsites/moleculardevices/blob/main/blocks/citations/citations.js#L83-L110
* https://github.com/hlxsites/moleculardevices/blob/main/blocks/social-share/social-share.js#L25-L35

Another example from a Pro Bono project:
https://github.com/fieitas/website/blob/main/blocks/covid-19-accordion/covid-19-accordion.js#L9-L99

## Other projects

The reason why I thought it would be a good addition to the block party repo is that I found similar/partial implementations, some repeating between projects, some independently written.

1. Adobe.com: https://blog.adobe.com/blocks/block-helpers.js
2. Volvo Trucks: https://github.com/hlxsites/vg-volvotrucks-us/blob/main/scripts/scripts.js#L40-L53
3. Caesars: https://github.com/hlxsites/caesars/blob/main/caesars-palace/scripts/scripts.js#L244-L263
4. Airlessco: https://github.com/hlxsites/airlessco/blob/main/scripts/scripts.js#L119-L134
5. WKND: https://github.com/hlxsites/wknd/blob/main/scripts/scripts.js#L50-L69 
6. Mammotome: https://github.com/hlxsites/mammotome/pull/67/files#diff-a5ee87ff9063f921ba01933977e6164e5729551986030f0ed7eb747bcffb740fR228 (Thank you, @karlpauls!)

 
## Credits

This is of course inspired by the JSX (React) syntax, articles and code pieces explaining its internals.